### PR TITLE
fix(hash): Don't use specific encoding

### DIFF
--- a/blockchain/chain.py
+++ b/blockchain/chain.py
@@ -39,7 +39,7 @@ class Block:
             Method to calculate hash from metadata
         """
         hashData = str(self.index) + str(self.data) + self.timestamp + self.previousHash + str(self.nonce)
-        return hashlib.sha256(hashData.encode("utf8")).hexdigest()
+        return hashlib.sha256(bytes(ord(x) for x in hashData)).hexdigest()
 
     def mineBlock(self, difficulty):
         """


### PR DESCRIPTION
Tested on python 3.7.2 with:

```
> python
Python 3.7.2
Type "help", "copyright", "credits" or "license" for more information.
>>> bytes(ord(x) for x in "é")
b'\xe9'
```